### PR TITLE
Feature diagrams should scroll automatically if a feature or constraint is moved to the border of the visible area

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/META-INF/MANIFEST.MF
+++ b/plugins/de.ovgu.featureide.fm.ui/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle:
  org.eclipse.ui.views,
  org.eclipse.gef,
  org.eclipse.core.expressions,
- de.ovgu.featureide.fm.core
+ de.ovgu.featureide.fm.core,
+ org.eclipse.draw2d
 Bundle-ActivationPolicy: lazy
 Export-Package: de.ovgu.featureide.fm.ui,
  de.ovgu.featureide.fm.ui.editors;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/ChillScrollFreeformRootEditPart.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/ChillScrollFreeformRootEditPart.java
@@ -1,0 +1,44 @@
+/* FeatureIDE - A Framework for Feature-Oriented Software Development
+ * Copyright (C) 2005-2017  FeatureIDE team, University of Magdeburg, Germany
+ *
+ * This file is part of FeatureIDE.
+ * 
+ * FeatureIDE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * FeatureIDE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FeatureIDE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See http://featureide.cs.ovgu.de/ for further information.
+ */
+package de.ovgu.featureide.fm.ui;
+
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.gef.AutoexposeHelper;
+import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
+
+import de.ovgu.featureide.fm.ui.utils.FullViewportAutoexposeHelper;
+
+/**
+ * Provides a better DND auto scroll behavior
+ */
+public class ChillScrollFreeformRootEditPart extends ScalableFreeformRootEditPart {
+
+	@Override
+	public Object getAdapter(Class adapter) {
+		if (adapter == AutoexposeHelper.class) {
+			Insets insets = new Insets(50);
+			float speed = 2;
+			return new FullViewportAutoexposeHelper(this, insets, speed);
+		}
+		return super.getAdapter(adapter);
+	}
+
+}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -57,7 +57,6 @@ import org.eclipse.gef.KeyStroke;
 import org.eclipse.gef.LayerConstants;
 import org.eclipse.gef.commands.CommandStack;
 import org.eclipse.gef.editparts.AbstractGraphicalEditPart;
-import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
 import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gef.ui.actions.GEFActionConstants;
 import org.eclipse.gef.ui.actions.ZoomInAction;
@@ -105,6 +104,7 @@ import de.ovgu.featureide.fm.core.io.manager.FileHandler;
 import de.ovgu.featureide.fm.core.job.LongRunningJob;
 import de.ovgu.featureide.fm.core.job.LongRunningMethod;
 import de.ovgu.featureide.fm.core.job.monitor.IMonitor;
+import de.ovgu.featureide.fm.ui.ChillScrollFreeformRootEditPart;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
 import de.ovgu.featureide.fm.ui.editors.elements.GraphicalFeatureModel;
 import de.ovgu.featureide.fm.ui.editors.elements.GraphicalFeatureModelFormat;
@@ -181,7 +181,7 @@ public class FeatureDiagramEditor extends ScrollingGraphicalViewer implements GU
 	private final IPersistentFormat<IGraphicalFeatureModel> format = new GraphicalFeatureModelFormat();
 	private final Path extraPath;
 
-	private ScalableFreeformRootEditPart rootEditPart;
+	private ChillScrollFreeformRootEditPart rootEditPart;
 
 	private CalculateDependencyAction calculateDependencyAction;
 	private CreateLayerAction createLayerAction;
@@ -402,7 +402,7 @@ public class FeatureDiagramEditor extends ScrollingGraphicalViewer implements GU
 		});
 		getControl().setBackground(FMPropertyManager.getDiagramBackgroundColor());
 		setEditPartFactory(new GraphicalEditPartFactory());
-		rootEditPart = new ScalableFreeformRootEditPart();
+		rootEditPart = new ChillScrollFreeformRootEditPart();
 		((ConnectionLayer) rootEditPart.getLayer(LayerConstants.CONNECTION_LAYER)).setAntialias(SWT.ON);
 		setRootEditPart(rootEditPart);
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/FullViewportAutoexposeHelper.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/FullViewportAutoexposeHelper.java
@@ -1,0 +1,151 @@
+/* FeatureIDE - A Framework for Feature-Oriented Software Development
+ * Copyright (C) 2005-2017  FeatureIDE team, University of Magdeburg, Germany
+ *
+ * This file is part of FeatureIDE.
+ * 
+ * FeatureIDE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * FeatureIDE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FeatureIDE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See http://featureide.cs.ovgu.de/ for further information.
+ */
+package de.ovgu.featureide.fm.ui.utils;
+
+import org.eclipse.draw2d.PositionConstants;
+import org.eclipse.draw2d.Viewport;
+import org.eclipse.draw2d.geometry.Insets;
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.gef.GraphicalEditPart;
+import org.eclipse.gef.editparts.ViewportAutoexposeHelper;
+
+/**
+ * Autoexposer which allows the pointer to be outside of the viewport
+ * 
+ * Refactered version of VIewportAutoexposeHelper. Does not implement AutoexposeHelper by itself because ViewportHelper is not visible.
+ */
+public class FullViewportAutoexposeHelper extends ViewportAutoexposeHelper {
+
+	/**
+	 * Simple stop watch
+	 * 
+	 * TODO: Is there any equivalent class in the APIs?
+	 */
+	private class Timer {
+
+		private long lastTime = 0;
+
+		/**
+		 * Deactivates the timer
+		 */
+		public void reset() {
+			lastTime = 0;
+		}
+
+		/**
+		 * Returns the number of milliseconds since the last invocation
+		 * 
+		 * If the timer have not been started yet, start the timer and return 0
+		 * 
+		 * @return milliseconds since last call, or 0 if the timer was not active
+		 */
+		public long get() {
+			final long current = System.currentTimeMillis();
+			if (0 == lastTime) {
+				lastTime = current;
+				return 0;
+			}
+			final long difference = current - lastTime;
+			lastTime = current;
+			return difference;
+		}
+	}
+
+	private Insets insets;
+	private Timer timer = new Timer();
+	final private float speed;
+
+	public FullViewportAutoexposeHelper(GraphicalEditPart owner, Insets finsets, float fspeed) {
+		super(owner, finsets);
+		insets = finsets;
+		speed = fspeed;
+	}
+
+	@Override
+	public boolean detect(Point point) {
+		timer.reset();
+		return shouldScroll(point);
+	}
+
+	@Override
+	public boolean step(Point point) {
+		if (!shouldScroll(point)) {
+			return false;
+		}
+
+		Viewport port = findViewport(owner);
+		Point oldLoc = port.getViewLocation();
+		Point newLoc = getNewLoc(oldLoc, getRect().getPosition(point), getOffset());
+		port.setViewLocation(newLoc);
+		return true;
+	}
+
+	private boolean shouldScroll(Point point) {
+		return !getRect().contains(point);
+	}
+
+	/**
+	 * Returns the bounds of the area which is not sensitive to DND
+	 * 
+	 * @return the bounds
+	 */
+	private Rectangle getRect() {
+		Viewport port = findViewport(owner);
+
+		Rectangle rect = Rectangle.SINGLETON.getCopy();
+		port.getClientArea(rect);
+		port.translateToParent(rect);
+		port.translateToAbsolute(rect);
+		rect.crop(insets);
+
+		return rect;
+	}
+
+	/**
+	 * Calculates a new viewport position
+	 * 
+	 * @param old old position
+	 * @param direction @see org.eclipse.draw2d.PositionConstants
+	 * @param scrollOffset absolute offset value
+	 * @return
+	 */
+	private Point getNewLoc(Point old, int direction, int scrollOffset) {
+		Point loc = old.getCopy();
+		if ((direction & PositionConstants.SOUTH) != 0) loc.y += scrollOffset;
+		else if ((direction & PositionConstants.NORTH) != 0) loc.y -= scrollOffset;
+
+		if ((direction & PositionConstants.EAST) != 0) loc.x += scrollOffset;
+		else if ((direction & PositionConstants.WEST) != 0) loc.x -= scrollOffset;
+
+		return loc;
+	}
+
+	/**
+	 * Calculate the offset incorporating the speed factor and the time
+	 * 
+	 * @return offset
+	 */
+	private int getOffset() {
+		return (int) (timer.get() * speed);
+	}
+
+}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/FullViewportAutoexposeHelper.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/FullViewportAutoexposeHelper.java
@@ -94,13 +94,13 @@ public class FullViewportAutoexposeHelper extends ViewportAutoexposeHelper {
 
 		Viewport port = findViewport(owner);
 		Point oldLoc = port.getViewLocation();
-		Point newLoc = getNewLoc(oldLoc, getRect().getPosition(point), getOffset());
+		Point newLoc = getNewLocation(oldLoc, getInnerBounds().getPosition(point), getOffset());
 		port.setViewLocation(newLoc);
 		return true;
 	}
 
 	private boolean shouldScroll(Point point) {
-		return !getRect().contains(point);
+		return !getInnerBounds().contains(point);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public class FullViewportAutoexposeHelper extends ViewportAutoexposeHelper {
 	 * 
 	 * @return the bounds
 	 */
-	private Rectangle getRect() {
+	private Rectangle getInnerBounds() {
 		Viewport port = findViewport(owner);
 
 		Rectangle rect = Rectangle.SINGLETON.getCopy();
@@ -128,7 +128,7 @@ public class FullViewportAutoexposeHelper extends ViewportAutoexposeHelper {
 	 * @param scrollOffset absolute offset value
 	 * @return
 	 */
-	private Point getNewLoc(Point old, int direction, int scrollOffset) {
+	private Point getNewLocation(Point old, int direction, int scrollOffset) {
 		Point loc = old.getCopy();
 		if ((direction & PositionConstants.SOUTH) != 0) loc.y += scrollOffset;
 		else if ((direction & PositionConstants.NORTH) != 0) loc.y -= scrollOffset;


### PR DESCRIPTION
enlarge the areas wich are sensitive to DND mouse hover
allow autoscroll when the pointer is out of the viewport